### PR TITLE
Auth 리팩토링

### DIFF
--- a/src/main/java/com/example/luvisluvproject/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/luvisluvproject/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.luvisluvproject.domain.auth.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,10 @@ import com.example.luvisluvproject.domain.auth.dto.response.LoginResponseDto;
 import com.example.luvisluvproject.domain.auth.dto.response.SignupResponseDto;
 import com.example.luvisluvproject.domain.auth.service.AuthService;
 import com.example.luvisluvproject.global.config.JwtUtil;
+import com.example.luvisluvproject.global.error.CustomRuntimeException;
+import com.example.luvisluvproject.global.error.ExceptionCode;
+import com.example.luvisluvproject.global.success.ApiResponse;
+import com.example.luvisluvproject.global.success.SuccessCode;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -32,8 +37,12 @@ public class AuthController {
 	 * @return 가입된 회원 정보를 담은 응답 DTO와 200 OK 상태
 	 */
 	@PostMapping("/signup")
-	public ResponseEntity<SignupResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
-		return ResponseEntity.ok(authService.signup(requestDto));
+	public ResponseEntity<ApiResponse<SignupResponseDto>> signup(
+		@Valid @RequestBody SignupRequestDto requestDto
+	) {
+		SignupResponseDto responseDto = authService.signup(requestDto);
+		ApiResponse<SignupResponseDto> apiResponse = ApiResponse.of(SuccessCode.SIGNUP_SUCCESS, responseDto);
+		return ResponseEntity.ok(apiResponse);
 	}
 
 	/**
@@ -43,8 +52,12 @@ public class AuthController {
 	 * @return JWT 토큰 정보가 담긴 응답 DTO와 200 OK 상태
 	 */
 	@PostMapping("/login")
-	public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto) {
-		return ResponseEntity.ok(authService.login(requestDto));
+	public ResponseEntity<ApiResponse<LoginResponseDto>> login(
+		@Valid @RequestBody LoginRequestDto requestDto
+	) {
+		LoginResponseDto responseDto = authService.login(requestDto);
+		ApiResponse<LoginResponseDto> apiResponse = ApiResponse.of(SuccessCode.LOGIN_SUCCESS, responseDto);
+		return ResponseEntity.ok(apiResponse);
 	}
 
 	/**
@@ -54,10 +67,14 @@ public class AuthController {
 	 * @return 성공 메시지
 	 */
 	@PostMapping("/logout")
-	public ResponseEntity<String> logout(HttpServletRequest request) {
+	public ResponseEntity<ApiResponse<Void>> logout(
+		HttpServletRequest request
+	) {
 		String accessToken = jwtUtil.resolveToken(request);
 		authService.logout(accessToken);
-		return ResponseEntity.ok("로그아웃 되었습니다.");
+
+		ApiResponse<Void> apiResponse = ApiResponse.of(SuccessCode.LOGOUT_SUCCESS, null);
+		return ResponseEntity.ok(apiResponse);
 	}
 
 }

--- a/src/main/java/com/example/luvisluvproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/luvisluvproject/domain/auth/service/AuthService.java
@@ -38,8 +38,9 @@ public class AuthService {
 	 * @param requestDto 회원 가입 요청 정보
 	 * @return 가입된 회원 정보가 담긴 응답 DTO
 	 * @throws CustomRuntimeException 이메일 중복일 경우 {@code ExceptionCode.EMAIL_ALREADY_EXIST}
+	 * @throws CustomRuntimeException 이름 중복일 경우 {@code ExceptionCode.NAME_ALREADY_EXIST}
+	 * @throws CustomRuntimeException 미성년자 확인 {@code ExceptionCode.UNDERAGE_USER}
 	 */
-	// todo 미성년자 체크 로직 추가해야함 !!
 	@Transactional
 	public SignupResponseDto signup(SignupRequestDto requestDto) {
 

--- a/src/main/java/com/example/luvisluvproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/luvisluvproject/domain/auth/service/AuthService.java
@@ -115,7 +115,7 @@ public class AuthService {
 		String accessToken = jwtUtil.createAccessToken(member.getEmail(), member.getUserRole().name());
 		String refreshToken = jwtUtil.createRefreshToken(member.getEmail());
 
-		return new LoginResponseDto(accessToken, refreshToken);
+		return new LoginResponseDto("Bearer " + accessToken, "Bearer " + refreshToken);
 
 	}
 

--- a/src/main/java/com/example/luvisluvproject/domain/member/enums/UserRole.java
+++ b/src/main/java/com/example/luvisluvproject/domain/member/enums/UserRole.java
@@ -9,7 +9,8 @@ import com.example.luvisluvproject.global.error.CustomRuntimeException;
 import com.example.luvisluvproject.global.error.ExceptionCode;
 
 public enum UserRole {
-	USER, MANAGER;
+	// USER(일반 회원), MANAGER(가게 사장님), ADMIN(관리자);
+	USER, MANAGER, ADMIN;
 
 	// userrole 타입변경 메서드 string -> userrole
 	public static UserRole of(String role) {

--- a/src/main/java/com/example/luvisluvproject/global/success/SuccessCode.java
+++ b/src/main/java/com/example/luvisluvproject/global/success/SuccessCode.java
@@ -8,6 +8,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SuccessCode {
+	SIGNUP_SUCCESS(HttpStatus.OK, "회원가입 완료"),
+	LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
+	LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공"),
+
 	FIND_MEMBER_SUCCESS(HttpStatus.OK, "회원 조회 성공"),
 	UPDATE_MEMBER_SUCCESS(HttpStatus.OK, "회원정보 수정 성공"),
 	DELETE_MEMBER_SUCCESS(HttpStatus.OK, "회원 탈퇴 완료");

--- a/src/test/java/com/example/luvisluvproject/domain/auth/AuthServiceTest.java
+++ b/src/test/java/com/example/luvisluvproject/domain/auth/AuthServiceTest.java
@@ -142,8 +142,8 @@ public class AuthServiceTest {
 
 		LoginResponseDto response = authService.login(dto);
 
-		assertEquals("access-token", response.getAccessToken());
-		assertEquals("refresh-token", response.getRefreshToken());
+		assertEquals("Bearer access-token", response.getAccessToken());
+		assertEquals("Bearer refresh-token", response.getRefreshToken());
 	}
 
 	@Test
@@ -160,7 +160,6 @@ public class AuthServiceTest {
 	@Test
 	@DisplayName("유효한 토큰이면 블랙리스트에 저장")
 	void logoutSuccess() {
-		// given
 		String token = "valid-token";
 		long expiration = 60000L;
 
@@ -169,10 +168,8 @@ public class AuthServiceTest {
 		given(jwtUtil.validateToken(token)).willReturn(true);
 		given(jwtUtil.getExpiration(token)).willReturn(expiration);
 
-		// when + then
 		assertDoesNotThrow(() -> authService.logout(token));
 
-		// then: redisTemplate에 해당 토큰을 블랙리스트로 저장
 		then(redisTemplate.opsForValue()).should()
 			.set(token, "logout", expiration, TimeUnit.MILLISECONDS);
 	}

--- a/src/test/java/com/example/luvisluvproject/domain/auth/AuthServiceTest.java
+++ b/src/test/java/com/example/luvisluvproject/domain/auth/AuthServiceTest.java
@@ -1,0 +1,179 @@
+package com.example.luvisluvproject.domain.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.example.luvisluvproject.domain.auth.dto.request.LoginRequestDto;
+import com.example.luvisluvproject.domain.auth.dto.request.SignupRequestDto;
+import com.example.luvisluvproject.domain.auth.dto.response.LoginResponseDto;
+import com.example.luvisluvproject.domain.auth.dto.response.SignupResponseDto;
+import com.example.luvisluvproject.domain.auth.service.AuthService;
+import com.example.luvisluvproject.domain.member.entity.Member;
+import com.example.luvisluvproject.domain.member.enums.UserRole;
+import com.example.luvisluvproject.domain.member.repository.MemberRepository;
+import com.example.luvisluvproject.global.config.JwtUtil;
+import com.example.luvisluvproject.global.error.CustomRuntimeException;
+import com.example.luvisluvproject.global.error.ExceptionCode;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private PasswordEncoder passwordEncoder;
+
+	@Mock
+	private JwtUtil jwtUtil;
+
+	@Mock
+	private RedisTemplate<String, String> redisTemplate;
+
+	@InjectMocks
+	private AuthService authService;
+
+	@Test
+	@DisplayName("회원가입 성공")
+	void signupSuccess() {
+		SignupRequestDto dto = new SignupRequestDto("박회원", "park1@email.com", "Test1234!",
+			LocalDate.of(2000, 1, 1), "USER");
+		given(memberRepository.existsByEmail(anyString())).willReturn(false); // 이메일 중복 아님
+		given(memberRepository.existsByName(anyString())).willReturn(false); // 이름 중복 아님
+		given(passwordEncoder.encode(anyString())).willReturn("encoded_pw"); // 비밀번호 암호화 결과
+		given(memberRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0)); // 저장된 멤버 그대로 반환
+
+		SignupResponseDto response = authService.signup(dto);
+
+		assertEquals("박회원", response.getName());
+		assertEquals("park1@email.com", response.getEmail());
+	}
+
+	@Test
+	@DisplayName("이메일 중복이면 예외 발생")
+	void emailDuplicate() {
+		SignupRequestDto dto = new SignupRequestDto("박회원", "park1@email.com", "Test1234!",
+			LocalDate.of(2000, 1, 1), "USER");
+		given(memberRepository.existsByEmail(anyString())).willReturn(true); // 이메일 중복
+
+		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.signup(dto));
+
+		assertEquals(ExceptionCode.EMAIL_ALREADY_EXIST, ex.getExceptionCode());
+	}
+
+	@Test
+	@DisplayName("이름 중복이면 예외 발생")
+	void nameDuplicate() {
+		SignupRequestDto dto = new SignupRequestDto("박회원", "park1@email.com", "Test1234!",
+			LocalDate.of(2000, 1, 1), "USER");
+		given(memberRepository.existsByEmail(anyString())).willReturn(false); // 이메일 중복 X
+		given(memberRepository.existsByName(anyString())).willReturn(true);  // 이름 중복 O
+
+		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.signup(dto));
+
+		assertEquals(ExceptionCode.NAME_ALREADY_EXIST, ex.getExceptionCode());
+	}
+
+	@Test
+	@DisplayName("만 19세 미만이면 예외 발생")
+	void underage() {
+		SignupRequestDto dto = new SignupRequestDto("박회원", "park1@email.com", "Test1234!",
+			LocalDate.of(2010, 1, 1), "USER"); // 미성년자
+		given(memberRepository.existsByEmail(anyString())).willReturn(false); // 이메일 중복 X
+		given(memberRepository.existsByName(anyString())).willReturn(false); // 이름 중복 X
+
+		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.signup(dto));
+
+		assertEquals(ExceptionCode.UNDERAGE_USER, ex.getExceptionCode());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 이메일이면 예외 발생")
+	void memberNotFound() {
+		LoginRequestDto dto = new LoginRequestDto("park1@email.com", "Test1234!");
+		given(memberRepository.findByEmail(anyString())).willReturn(Optional.empty());
+
+		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.login(dto));
+
+		assertEquals(ExceptionCode.MEMBER_NOT_FOUND, ex.getExceptionCode());
+	}
+
+	@Test
+	@DisplayName("비밀번호 불일치시 예외 발생")
+	void passwordMismatch() {
+		Member member = new Member("박회원", "park1@email.com", "Test1234!",
+			LocalDate.of(2000, 1, 1), UserRole.USER); // 저장된 회원 정보
+		LoginRequestDto dto = new LoginRequestDto("park1@email.com", "Test1234@@@"); // 로그인 시도 정보
+		given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(member)); // 이메일로 회원 조회됨
+		given(passwordEncoder.matches(anyString(), anyString())).willReturn(false); // 비밀번호 일치하지 않음
+
+		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.login(dto));
+
+		assertEquals(ExceptionCode.LOGIN_FAILED, ex.getExceptionCode());
+	}
+
+	@Test
+	@DisplayName("정상 로그인 시 토큰 발급")
+	void loginSuccess() {
+		Member member = new Member("박회원", "park1@email.com", "encoded_pw",
+			LocalDate.of(2000, 1, 1), UserRole.USER); // 가입된 회원
+		LoginRequestDto dto = new LoginRequestDto("park1@email.com", "encoded_pw"); // 로그인 요청
+
+		given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(member)); // 이메일로 회원 조회 성공
+		given(passwordEncoder.matches(anyString(), anyString())).willReturn(true); // 비밀번호 일치
+		given(jwtUtil.createAccessToken(any(), any())).willReturn("access-token"); // Access 토큰 생성
+		given(jwtUtil.createRefreshToken(any())).willReturn("refresh-token");     // Refresh 토큰 생성
+
+		LoginResponseDto response = authService.login(dto);
+
+		assertEquals("access-token", response.getAccessToken());
+		assertEquals("refresh-token", response.getRefreshToken());
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 토큰이면 예외 발생")
+	void invalidToken() {
+		String token = "invalid-token";
+		given(jwtUtil.validateToken(token)).willReturn(false); // 토큰 검증 실패
+
+		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.logout(token));
+
+		assertEquals(ExceptionCode.INVALID_TOKEN, ex.getExceptionCode());
+	}
+
+	@Test
+	@DisplayName("유효한 토큰이면 블랙리스트에 저장")
+	void logoutSuccess() {
+		// given
+		String token = "valid-token";
+		long expiration = 60000L;
+
+		ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+		given(redisTemplate.opsForValue()).willReturn(valueOperations);
+		given(jwtUtil.validateToken(token)).willReturn(true);
+		given(jwtUtil.getExpiration(token)).willReturn(expiration);
+
+		// when + then
+		assertDoesNotThrow(() -> authService.logout(token));
+
+		// then: redisTemplate에 해당 토큰을 블랙리스트로 저장
+		then(redisTemplate.opsForValue()).should()
+			.set(token, "logout", expiration, TimeUnit.MILLISECONDS);
+	}
+}


### PR DESCRIPTION
## ✨ PR 제목
Auth 관련 리팩토링

---

## 📌 구현 내용
- UserRole에 ADMIN(관리자) 추가
- AuthService 주요기능 test code 추가
- ApiResponse 추가
- 로그인 후 토큰 발급시 Bearer 이 명시되지 않는 문제 수정

## 🧪 테스트 내역
- ✅ Postman / http 파일로 테스트 완료
- ✅ JUnit 테스트 통과
- ✅ DB 반영 확인

## 🔗 관련 이슈
.

## 📎 기타 참고 사항

