### PR TITLE
Auth 리팩토링 및 UserRole별 회원가입 url 분리

### DIFF
--- a/src/main/java/com/example/luvisluvproject/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/luvisluvproject/domain/auth/controller/AuthController.java
@@ -1,7 +1,6 @@
 package com.example.luvisluvproject.domain.auth.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,8 +12,6 @@ import com.example.luvisluvproject.domain.auth.dto.response.LoginResponseDto;
 import com.example.luvisluvproject.domain.auth.dto.response.SignupResponseDto;
 import com.example.luvisluvproject.domain.auth.service.AuthService;
 import com.example.luvisluvproject.global.config.JwtUtil;
-import com.example.luvisluvproject.global.error.CustomRuntimeException;
-import com.example.luvisluvproject.global.error.ExceptionCode;
 import com.example.luvisluvproject.global.success.ApiResponse;
 import com.example.luvisluvproject.global.success.SuccessCode;
 
@@ -31,16 +28,46 @@ public class AuthController {
 	private final JwtUtil jwtUtil;
 
 	/**
-	 * 회원가입 요청 컨트롤러
+	 * 일반 유저 회원가입 요청 컨트롤러
 	 *
 	 * @param requestDto 회원가입 요청 데이터
 	 * @return 가입된 회원 정보를 담은 응답 DTO와 200 OK 상태
 	 */
-	@PostMapping("/signup")
-	public ResponseEntity<ApiResponse<SignupResponseDto>> signup(
+	@PostMapping("/signup/user")
+	public ResponseEntity<ApiResponse<SignupResponseDto>> signupUser(
 		@Valid @RequestBody SignupRequestDto requestDto
 	) {
-		SignupResponseDto responseDto = authService.signup(requestDto);
+		SignupResponseDto responseDto = authService.signupUser(requestDto);
+		ApiResponse<SignupResponseDto> apiResponse = ApiResponse.of(SuccessCode.SIGNUP_SUCCESS, responseDto);
+		return ResponseEntity.ok(apiResponse);
+	}
+
+	/**
+	 * 사장(MANAGER) 회원가입 요청 컨트롤러
+	 *
+	 * @param requestDto 회원가입 요청 데이터
+	 * @return 가입된 회원 정보를 담은 응답 DTO와 200 OK 상태
+	 */
+	@PostMapping("/signup/manager")
+	public ResponseEntity<ApiResponse<SignupResponseDto>> signupManager(
+		@Valid @RequestBody SignupRequestDto requestDto
+	) {
+		SignupResponseDto responseDto = authService.signupManager(requestDto);
+		ApiResponse<SignupResponseDto> apiResponse = ApiResponse.of(SuccessCode.SIGNUP_SUCCESS, responseDto);
+		return ResponseEntity.ok(apiResponse);
+	}
+
+	/**
+	 * 관리자(ADMIN) 회원가입 요청 컨트롤러
+	 *
+	 * @param requestDto 회원가입 요청 데이터
+	 * @return 가입된 회원 정보를 담은 응답 DTO와 200 OK 상태
+	 */
+	@PostMapping("/signup/admin")
+	public ResponseEntity<ApiResponse<SignupResponseDto>> signupAdmin(
+		@RequestBody @Valid SignupRequestDto requestDto
+	) {
+		SignupResponseDto responseDto = authService.signupAdmin(requestDto);
 		ApiResponse<SignupResponseDto> apiResponse = ApiResponse.of(SuccessCode.SIGNUP_SUCCESS, responseDto);
 		return ResponseEntity.ok(apiResponse);
 	}

--- a/src/main/java/com/example/luvisluvproject/domain/auth/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/example/luvisluvproject/domain/auth/dto/request/SignupRequestDto.java
@@ -29,10 +29,4 @@ public class SignupRequestDto {
 	@JsonFormat(pattern = "yyyy-MM-dd")
 	private final LocalDate birthday;
 
-	@NotBlank(message = "멤버 권한을 입력해주세요.")
-	private final String userRole;
-
-	//태그 선택해야함
-	@NotNull(message = "선택한 태그가 없습니다.")
-	private final List<Long> tagIds;
 }

--- a/src/main/java/com/example/luvisluvproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/luvisluvproject/domain/auth/service/AuthService.java
@@ -54,12 +54,16 @@ public class AuthService {
 			throw new CustomRuntimeException(ExceptionCode.NAME_ALREADY_EXIST);
 		}
 
-		// 미성년자 확인
-		// TODO 생일을 현재 날짜 이후로 설정한 경우 -> 예외
 		LocalDate birthday = requestDto.getBirthday();
 		LocalDate today = LocalDate.now();
-
-		if (birthday.plusYears(19).isAfter(today)) {
+		// 오늘 날짜 이후로 생일 설정한 경우
+		if (birthday.isAfter(today)) {
+			throw new CustomRuntimeException(ExceptionCode.INVALID_BIRTHDAY_IN_FUTURE);
+		}
+		// 미성년자 확인
+		if (birthday.plusYears(19)
+			.isAfter(
+				today)) { // 생일년도 + 19 한게 오늘 년도보다 많으면 ?? 안됨 / 2000년도 + 19 = 2019 < 오늘 2025년  -> ㄱㅊ / 2007년도 + 19 = 2026 > 오늘 2025년 미자 !!
 			throw new CustomRuntimeException(ExceptionCode.UNDERAGE_USER);
 		}
 

--- a/src/main/java/com/example/luvisluvproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/luvisluvproject/domain/auth/service/AuthService.java
@@ -55,6 +55,7 @@ public class AuthService {
 		}
 
 		// 미성년자 확인
+		// TODO 생일을 현재 날짜 이후로 설정한 경우 -> 예외
 		LocalDate birthday = requestDto.getBirthday();
 		LocalDate today = LocalDate.now();
 
@@ -68,6 +69,7 @@ public class AuthService {
 		// userRole string -> enum 변환
 		UserRole userRole = UserRole.of(requestDto.getUserRole());
 
+		// TODO userrole api 분리
 		Member member = new Member(
 			requestDto.getName(),
 			requestDto.getEmail(),
@@ -102,6 +104,7 @@ public class AuthService {
 			.orElseThrow(() -> new CustomRuntimeException(ExceptionCode.MEMBER_NOT_FOUND));
 
 		// 이메일 일치 확인
+		// TODO 불필요 -> 삭제
 		if (!requestDto.getEmail().equals(member.getEmail())) {
 			throw new CustomRuntimeException(ExceptionCode.LOGIN_FAILED);
 		}

--- a/src/main/java/com/example/luvisluvproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/luvisluvproject/domain/auth/service/AuthService.java
@@ -103,12 +103,6 @@ public class AuthService {
 		Member member = memberRepository.findByEmail(requestDto.getEmail())
 			.orElseThrow(() -> new CustomRuntimeException(ExceptionCode.MEMBER_NOT_FOUND));
 
-		// 이메일 일치 확인
-		// TODO 불필요 -> 삭제
-		if (!requestDto.getEmail().equals(member.getEmail())) {
-			throw new CustomRuntimeException(ExceptionCode.LOGIN_FAILED);
-		}
-
 		// 비밀번호 일치 확인
 		if (!passwordEncoder.matches(requestDto.getPassword(), member.getPassword())) {
 			throw new CustomRuntimeException(ExceptionCode.LOGIN_FAILED);

--- a/src/main/java/com/example/luvisluvproject/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/luvisluvproject/domain/auth/service/AuthService.java
@@ -1,8 +1,6 @@
 package com.example.luvisluvproject.domain.auth.service;
 
 import java.time.LocalDate;
-import java.time.Period;
-import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -33,16 +31,16 @@ public class AuthService {
 	private final RedisTemplate<String, String> redisTemplate;
 
 	/**
-	 * 회원가입
+	 * 일반회원(USER) 회원가입
 	 *
-	 * @param requestDto 회원 가입 요청 정보
+	 * @param requestDto 회원가입 요청 정보
 	 * @return 가입된 회원 정보가 담긴 응답 DTO
 	 * @throws CustomRuntimeException 이메일 중복일 경우 {@code ExceptionCode.EMAIL_ALREADY_EXIST}
 	 * @throws CustomRuntimeException 이름 중복일 경우 {@code ExceptionCode.NAME_ALREADY_EXIST}
 	 * @throws CustomRuntimeException 미성년자 확인 {@code ExceptionCode.UNDERAGE_USER}
 	 */
 	@Transactional
-	public SignupResponseDto signup(SignupRequestDto requestDto) {
+	public SignupResponseDto signupUser(SignupRequestDto requestDto) {
 
 		// 이메일 중복확인
 		if (memberRepository.existsByEmail(requestDto.getEmail())) {
@@ -61,25 +59,114 @@ public class AuthService {
 			throw new CustomRuntimeException(ExceptionCode.INVALID_BIRTHDAY_IN_FUTURE);
 		}
 		// 미성년자 확인
-		if (birthday.plusYears(19)
-			.isAfter(
-				today)) { // 생일년도 + 19 한게 오늘 년도보다 많으면 ?? 안됨 / 2000년도 + 19 = 2019 < 오늘 2025년  -> ㄱㅊ / 2007년도 + 19 = 2026 > 오늘 2025년 미자 !!
+		if (birthday.plusYears(19).isAfter(today)) {
 			throw new CustomRuntimeException(ExceptionCode.UNDERAGE_USER);
 		}
 
 		// 비밀번호 암호화
 		String encodePassword = passwordEncoder.encode(requestDto.getPassword());
 
-		// userRole string -> enum 변환
-		UserRole userRole = UserRole.of(requestDto.getUserRole());
-
-		// TODO userrole api 분리
 		Member member = new Member(
 			requestDto.getName(),
 			requestDto.getEmail(),
 			encodePassword,
 			requestDto.getBirthday(),
-			userRole
+			UserRole.USER
+		);
+
+		Member saved = memberRepository.save(member);
+
+		return new SignupResponseDto(
+			saved.getId(),
+			saved.getName(),
+			saved.getEmail(),
+			saved.getBirthday(),
+			saved.getUserRole()
+		);
+	}
+
+	/**
+	 * 사장(MANAGER) 회원가입
+	 * @param requestDto 회원가입 요청 정보
+	 * @return 가입된 회원 정보가 담긴 응답 DTO
+	 */
+	@Transactional
+	public SignupResponseDto signupManager(SignupRequestDto requestDto) {
+
+		if (memberRepository.existsByEmail(requestDto.getEmail())) {
+			throw new CustomRuntimeException(ExceptionCode.EMAIL_ALREADY_EXIST);
+		}
+
+		if (memberRepository.existsByName(requestDto.getName())) {
+			throw new CustomRuntimeException(ExceptionCode.NAME_ALREADY_EXIST);
+		}
+
+		LocalDate birthday = requestDto.getBirthday();
+		LocalDate today = LocalDate.now();
+
+		if (birthday.isAfter(today)) {
+			throw new CustomRuntimeException(ExceptionCode.INVALID_BIRTHDAY_IN_FUTURE);
+		}
+
+		if (birthday.plusYears(19).isAfter(today)) {
+			throw new CustomRuntimeException(ExceptionCode.UNDERAGE_USER);
+		}
+
+		String encodePassword = passwordEncoder.encode(requestDto.getPassword());
+
+		Member member = new Member(
+			requestDto.getName(),
+			requestDto.getEmail(),
+			encodePassword,
+			requestDto.getBirthday(),
+			UserRole.MANAGER
+		);
+
+		Member saved = memberRepository.save(member);
+
+		return new SignupResponseDto(
+			saved.getId(),
+			saved.getName(),
+			saved.getEmail(),
+			saved.getBirthday(),
+			saved.getUserRole()
+		);
+	}
+
+	/**
+	 * 관리자(ADMIN) 회원가입
+	 * @param requestDto 회원가입 요청 정보
+	 * @return 가입된 회원 정보가 담긴 응답 DTO
+	 */
+	@Transactional
+	public SignupResponseDto signupAdmin(SignupRequestDto requestDto) {
+		if (memberRepository.existsByEmail(requestDto.getEmail())) {
+			throw new CustomRuntimeException(ExceptionCode.EMAIL_ALREADY_EXIST);
+		}
+
+		if (memberRepository.existsByName(requestDto.getName())) {
+			throw new CustomRuntimeException(ExceptionCode.NAME_ALREADY_EXIST);
+		}
+
+		LocalDate birthday = requestDto.getBirthday();
+		LocalDate today = LocalDate.now();
+
+		if (birthday.isAfter(today)) {
+			throw new CustomRuntimeException(ExceptionCode.INVALID_BIRTHDAY_IN_FUTURE);
+		}
+
+		if (birthday.plusYears(19).isAfter(today)) {
+			throw new CustomRuntimeException(ExceptionCode.UNDERAGE_USER);
+		}
+
+		String encodePassword = passwordEncoder.encode(requestDto.getPassword());
+
+		Member member = new Member(
+			requestDto.getName(),
+			requestDto.getEmail(),
+			encodePassword,
+			requestDto.getBirthday(),
+			UserRole.ADMIN
 		);
 
 		Member saved = memberRepository.save(member);

--- a/src/main/java/com/example/luvisluvproject/domain/member/entity/Member.java
+++ b/src/main/java/com/example/luvisluvproject/domain/member/entity/Member.java
@@ -68,12 +68,16 @@ public class Member extends BaseEntity {
 	@OneToMany(mappedBy = "member")
 	private List<MemberTag> memberTagList;
 
+	// 새 멤버 생성시 사용하는 생성자
 	public Member(String name, String email, String password, LocalDate birthday, UserRole userRole) {
 		this.name = name;
 		this.email = email;
 		this.password = password;
 		this.birthday = birthday;
 		this.userRole = userRole;
+		this.status = false;
+		this.likeCount = 0L;
+		this.reportCount = 0;
 	}
 
 	public Member(Long id, String name, String email, String password, LocalDate birthday, UserRole userRole,

--- a/src/main/java/com/example/luvisluvproject/global/config/JwtFilter.java
+++ b/src/main/java/com/example/luvisluvproject/global/config/JwtFilter.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -32,6 +33,7 @@ public class JwtFilter extends OncePerRequestFilter {
 	private final JwtUtil jwtUtil;
 	private final UserDetailsServiceImpl userDetailsService;
 	private final RedisTemplate<String, String> redisTemplate;
+	private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -39,25 +41,29 @@ public class JwtFilter extends OncePerRequestFilter {
 
 		List<String> whitelist = List.of(
 			"/auth/login",
-			"/auth/signup",
+			"/auth/signup/**",
 			"/ws/**"
 		);
 
 		String requestUri = request.getRequestURI();
 
-		if (whitelist.contains(requestUri)) {
-			filterChain.doFilter(request, response);
-			return;
+		for (String pattern : whitelist) {
+			if (pathMatcher.match(pattern, requestUri)) {
+				filterChain.doFilter(request, response);
+				return;
+			}
 		}
 
 		String token = jwtUtil.resolveToken(request);
 
 		// Redis에 로그아웃(블랙리스트) 처리된 토큰인지 확인
-		String isLogout = redisTemplate.opsForValue().get(token);
-		if ("logout".equals(isLogout)) {
-			log.info("로그아웃된 토큰으로 접근 시도");
-			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그아웃된 토큰입니다.");
-			return;
+		if (token != null) {
+			String isLogout = redisTemplate.opsForValue().get(token);
+			if ("logout".equals(isLogout)) {
+				log.info("로그아웃된 토큰으로 접근 시도");
+				response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그아웃된 토큰입니다.");
+				return;
+			}
 		}
 
 		if (StringUtils.hasText(token) && jwtUtil.validateToken(token)) {

--- a/src/main/java/com/example/luvisluvproject/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/luvisluvproject/global/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
 		http
 			.csrf((csrf) -> csrf.disable())
 			.authorizeHttpRequests((authz) -> authz
-				.requestMatchers("/auth/signup", "/auth/login", "/ws/**").permitAll()
+				.requestMatchers("/auth/signup/**", "/auth/login", "/ws/**").permitAll()
 				.anyRequest().authenticated()
 			)
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/luvisluvproject/global/error/ExceptionCode.java
+++ b/src/main/java/com/example/luvisluvproject/global/error/ExceptionCode.java
@@ -19,6 +19,7 @@ public enum ExceptionCode implements ErrorCode {
 	LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "이메일 혹은 비밀번호가 올바르지 않습니다."),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 	UNDERAGE_USER(HttpStatus.FORBIDDEN, "만 19세 미만은 이용할 수 없습니다."),
+	INVALID_BIRTHDAY_IN_FUTURE(HttpStatus.BAD_REQUEST, "생일은 미래 날짜로 설정할 수 없습니다."),
 
 	//가게
 	STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가게를 찾을 수 없습니다."),

--- a/src/test/java/com/example/luvisluvproject/domain/auth/AuthServiceTest.java
+++ b/src/test/java/com/example/luvisluvproject/domain/auth/AuthServiceTest.java
@@ -50,29 +50,64 @@ public class AuthServiceTest {
 	private AuthService authService;
 
 	@Test
-	@DisplayName("회원가입 성공")
-	void signupSuccess() {
+	@DisplayName("유저 회원가입 성공")
+	void signupUserSuccess() {
 		SignupRequestDto dto = new SignupRequestDto("박회원", "park1@email.com", "Test1234!",
-			LocalDate.of(2000, 1, 1), "USER");
+			LocalDate.of(2000, 1, 1));
 		given(memberRepository.existsByEmail(anyString())).willReturn(false); // 이메일 중복 아님
 		given(memberRepository.existsByName(anyString())).willReturn(false); // 이름 중복 아님
 		given(passwordEncoder.encode(anyString())).willReturn("encoded_pw"); // 비밀번호 암호화 결과
 		given(memberRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0)); // 저장된 멤버 그대로 반환
 
-		SignupResponseDto response = authService.signup(dto);
+		SignupResponseDto response = authService.signupUser(dto);
 
 		assertEquals("박회원", response.getName());
 		assertEquals("park1@email.com", response.getEmail());
+		assertEquals(UserRole.USER, response.getUserRole());
+	}
+
+	@Test
+	@DisplayName("사장 회원가입 성공")
+	void signupManagerSuccess() {
+		SignupRequestDto dto = new SignupRequestDto("김사장", "kim1@email.com", "Test1234!",
+			LocalDate.of(2000, 1, 1));
+		given(memberRepository.existsByEmail(anyString())).willReturn(false); // 이메일 중복 아님
+		given(memberRepository.existsByName(anyString())).willReturn(false); // 이름 중복 아님
+		given(passwordEncoder.encode(anyString())).willReturn("encoded_pw"); // 비밀번호 암호화 결과
+		given(memberRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0)); // 저장된 멤버 그대로 반환
+
+		SignupResponseDto response = authService.signupManager(dto);
+
+		assertEquals("김사장", response.getName());
+		assertEquals("kim1@email.com", response.getEmail());
+		assertEquals(UserRole.MANAGER, response.getUserRole());
+	}
+
+	@Test
+	@DisplayName("관리자 회원가입 성공")
+	void signupAdminSuccess() {
+		SignupRequestDto dto = new SignupRequestDto("정관리", "jung1@email.com", "Test1234!",
+			LocalDate.of(2000, 1, 1));
+		given(memberRepository.existsByEmail(anyString())).willReturn(false); // 이메일 중복 아님
+		given(memberRepository.existsByName(anyString())).willReturn(false); // 이름 중복 아님
+		given(passwordEncoder.encode(anyString())).willReturn("encoded_pw"); // 비밀번호 암호화 결과
+		given(memberRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0)); // 저장된 멤버 그대로 반환
+
+		SignupResponseDto response = authService.signupAdmin(dto);
+
+		assertEquals("정관리", response.getName());
+		assertEquals("jung1@email.com", response.getEmail());
+		assertEquals(UserRole.ADMIN, response.getUserRole());
 	}
 
 	@Test
 	@DisplayName("이메일 중복이면 예외 발생")
 	void emailDuplicate() {
 		SignupRequestDto dto = new SignupRequestDto("박회원", "park1@email.com", "Test1234!",
-			LocalDate.of(2000, 1, 1), "USER");
+			LocalDate.of(2000, 1, 1));
 		given(memberRepository.existsByEmail(anyString())).willReturn(true); // 이메일 중복
 
-		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.signup(dto));
+		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.signupUser(dto));
 
 		assertEquals(ExceptionCode.EMAIL_ALREADY_EXIST, ex.getExceptionCode());
 	}
@@ -81,11 +116,11 @@ public class AuthServiceTest {
 	@DisplayName("이름 중복이면 예외 발생")
 	void nameDuplicate() {
 		SignupRequestDto dto = new SignupRequestDto("박회원", "park1@email.com", "Test1234!",
-			LocalDate.of(2000, 1, 1), "USER");
+			LocalDate.of(2000, 1, 1));
 		given(memberRepository.existsByEmail(anyString())).willReturn(false); // 이메일 중복 X
 		given(memberRepository.existsByName(anyString())).willReturn(true);  // 이름 중복 O
 
-		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.signup(dto));
+		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.signupUser(dto));
 
 		assertEquals(ExceptionCode.NAME_ALREADY_EXIST, ex.getExceptionCode());
 	}
@@ -94,13 +129,28 @@ public class AuthServiceTest {
 	@DisplayName("만 19세 미만이면 예외 발생")
 	void underage() {
 		SignupRequestDto dto = new SignupRequestDto("박회원", "park1@email.com", "Test1234!",
-			LocalDate.of(2010, 1, 1), "USER"); // 미성년자
+			LocalDate.of(2010, 1, 1)); // 미성년자
 		given(memberRepository.existsByEmail(anyString())).willReturn(false); // 이메일 중복 X
 		given(memberRepository.existsByName(anyString())).willReturn(false); // 이름 중복 X
 
-		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.signup(dto));
+		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.signupUser(dto));
 
 		assertEquals(ExceptionCode.UNDERAGE_USER, ex.getExceptionCode());
+	}
+
+	@Test
+	@DisplayName("생일이 오늘 날짜보다 미래면 예외 발생")
+	void birthdayInFutureThrowsException() {
+		LocalDate futureDate = LocalDate.now().plusDays(1); // 내일 날짜
+		SignupRequestDto dto = new SignupRequestDto("박회원", "park1@email.com", "Test1234!",
+			futureDate);
+
+		given(memberRepository.existsByEmail(anyString())).willReturn(false);
+		given(memberRepository.existsByName(anyString())).willReturn(false);
+
+		CustomRuntimeException ex = assertThrows(CustomRuntimeException.class, () -> authService.signupUser(dto));
+
+		assertEquals(ExceptionCode.INVALID_BIRTHDAY_IN_FUTURE, ex.getExceptionCode());
 	}
 
 	@Test


### PR DESCRIPTION
## ✨ PR 제목
Auth 리팩토링 및 UserRole별 회원가입 url 분리

---

## 📌 구현 내용
- 로그인 비즈니스 로직(auth/login) 내 불필요한 중복로직 삭제
- 회원가입 비즈니스 로직(auth/signup) 내 생일 관련 로직 수정 (생일이 현재 날짜 이후인 경우 예외처리)
- 유저권한별 회원가입 분리

## 🧪 테스트 내역
-✅ Postman / http 파일로 테스트 완료
-✅ JUnit 테스트 통과
-✅  DB 반영 확인

## 🔗 관련 이슈
.

## 📎 기타 참고 사항
.
